### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Wasp:Megastore&F1-like system#
+# Wasp:Megastore&F1-like system #
 
 * Introduction : [Project Page][1]
 * Documents :  [Wiki][2]
@@ -8,7 +8,7 @@ With the development of NoSQL, HBase gradually become the mainstream of the NoSQ
 
 Therefore, we decided to explore providing cross-row transactions, indexes, SQL function without sacrificing the linear expansion of capacity in the upper layer of the HBase by theoretical model MegaStore. The system provides simple user interface: SQL, the user can do not need to pay attention to the hbase schema design, greatly simplifies the user's data migration and learning costs. To see what's supported, go to our language reference guide, and read more on our [wiki][4].
 
-#Mission#
+# Mission #
 
 Become a standard distributed relational database,which's storage engine is nosql system, for example the hbase.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
