### PR TITLE
Reducing the chance of flaky test failure

### DIFF
--- a/src/test/java/com/alibaba/wasp/executor/TestExecutorService.java
+++ b/src/test/java/com/alibaba/wasp/executor/TestExecutorService.java
@@ -48,7 +48,7 @@ public class TestExecutorService {
   public void testExecutorService() throws Exception {
     int maxThreads = 5;
     int maxTries = 10;
-    int sleepInterval = 10;
+    int sleepInterval = 20;
 
     Server mockedServer = mock(Server.class);
     when(mockedServer.getConfiguration()).thenReturn(conf);


### PR DESCRIPTION
Description:
This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.

Failure:
Running com.alibaba.wasp.executor.TestExecutorService
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.249 sec <<< FAILURE!
testExecutorService(com.alibaba.wasp.executor.TestExecutorService)  Time elapsed: 0.166 sec  <<< FAILURE!
java.lang.AssertionError: expected:<10> but was:<5>
	at org.junit.Assert.fail(Assert.java:93)
	at org.junit.Assert.failNotEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:128)
	at org.junit.Assert.assertEquals(Assert.java:472)
	at org.junit.Assert.assertEquals(Assert.java:456)
	at com.alibaba.wasp.executor.TestExecutorService.testExecutorService(TestExecutorService.java:109)

Results :
Failed tests: 
  TestExecutorService.testExecutorService:109 expected:<10> but was:<5>

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

Solution: The chances of test failure is reduced simply increasing a bit more sleeping time.