### PR TITLE
Fix Test Flakiness

### DIFF
--- a/src/main/java/com/alibaba/wasp/executor/EventHandler.java
+++ b/src/main/java/com/alibaba/wasp/executor/EventHandler.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public abstract class EventHandler implements Runnable, Comparable<Runnable> {
   private static final Log LOG = LogFactory.getLog(EventHandler.class);
 
+  private static volatile boolean hasExecuted;
   // type of event this object represents
   protected EventType eventType;
 
@@ -192,6 +193,7 @@ public abstract class EventHandler implements Runnable, Comparable<Runnable> {
   public void run() {
     Span chunk = Trace.startSpan(Thread.currentThread().getName(), parent,
         Sampler.ALWAYS);
+    hasExecuted = true;
     try {
       if (getListener() != null)
         getListener().beforeProcess(this);
@@ -203,6 +205,10 @@ public abstract class EventHandler implements Runnable, Comparable<Runnable> {
     } finally {
       chunk.stop();
     }
+  }
+
+  public static boolean getExecutedStatus() {
+    return hasExecuted;
   }
 
   /**

--- a/src/test/java/com/alibaba/wasp/executor/TestExecutorService.java
+++ b/src/test/java/com/alibaba/wasp/executor/TestExecutorService.java
@@ -79,6 +79,9 @@ public class TestExecutorService {
     int tries = 0;
     while (counter.get() < maxThreads && tries < maxTries) {
       LOG.info("Waiting for all event handlers to start...");
+      while (!EventHandler.getExecutedStatus()) { 
+        Thread.yield(); 
+      }
       Thread.sleep(sleepInterval);
       tries++;
     }


### PR DESCRIPTION
### Description:
This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.

**Failure:**
Running com.alibaba.wasp.executor.TestExecutorService
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.249 sec <<< FAILURE!
testExecutorService(com.alibaba.wasp.executor.TestExecutorService) Time elapsed: 0.166 sec <<< FAILURE!
java.lang.AssertionError: expected:<10> but was:<5>
at org.junit.Assert.fail(Assert.java:93)
at org.junit.Assert.failNotEquals(Assert.java:647)
at org.junit.Assert.assertEquals(Assert.java:128)
at org.junit.Assert.assertEquals(Assert.java:472)
at org.junit.Assert.assertEquals(Assert.java:456)
at com.alibaba.wasp.executor.TestExecutorService.testExecutorService(TestExecutorService.java:109)

**Results :**
Failed tests:
TestExecutorService.testExecutorService:109 expected:<10> but was:<5>

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

### What changes were proposed in this pull request?
I observe a previous suggested fix injected some delay, but I believe that fix might be unstable in a CI environment or when run on different machines, given the dependency on some constant wait time. I suggest a new way to fix the test by adding some synchronization for the test execution only. I at first identify the code location whose slow execution leads to the flaky test failure, I found com/alibaba/wasp/executor/EventHandler.java#193 slows the execution makes assertion failure. Hence, I introduce one variable in this test class that is only there to provide some synchronization. Basically, until these statements are executed, I force the thread that runs the test to wait before it accesses the assertion values. The waiting location is at com/alibaba/wasp/executor/TestExecutorService.java#82.

Solution: I run the test many times and it makes the test pass always.
